### PR TITLE
Update cc gov action

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -365,7 +365,7 @@ create_governance_actions() {
     esac
 }
 
-# Function to add new CC memeber
+# Function to add new CC member
 add_new_CC() {
     govActDeposit="$(cardano-cli conway query gov-state --testnet-magic 4 | jq -r '.enactState.curPParams.govActionDeposit')"
 
@@ -376,11 +376,11 @@ add_new_CC() {
     read -p "Please provide us with the Governance Action: " governance_text
     echo "$user_text" > text.txt
 
-    # Asking the user for the key hash of a new CC memeber
-    read -p "Plese provide us with a key hash of a new CC memeber: " CC_memeber
+    # Asking the user for the key hash of a new CC member
+    read -p "Plese provide us with a key hash of a new CC memeber: " CC_member
 
     # Asking the user for an expiration epoch of the new CC member
-    read -p "Plese provide us with the expiration epoch of a new CC memeber: " expiration_memeber
+    read -p "Plese provide us with the expiration epoch of a new CC member: " expiration_member
 
     # Asking the user for quorum
     read -p "How many committee members will there be in total?" quorum_denominator
@@ -450,7 +450,7 @@ remove_CC_member() {
             --stake-verification-key-file stake.vkey \
             --proposal-anchor-url ${link} \
             --proposal-anchor-metadata-file ${governance_text} \
-            --remove-cc-cold-verification-key-hash ${CC_memeber} \
+            --remove-cc-cold-verification-key-hash ${CC_member} \
             --quorum ${quorum} \
             --governance-action-tx-id ${governance_action_tx_id} \
             --governance-action-index ${governacne_action_index} \
@@ -462,7 +462,7 @@ remove_CC_member() {
             --stake-verification-key-file stake.vkey \
             --proposal-anchor-url ${link} \
             --proposal-anchor-metadata-file ${governance_text} \
-            --remove-cc-cold-verification-key-hash ${CC_memeber} \
+            --remove-cc-cold-verification-key-hash ${CC_member} \
             --quorum ${quorum} \
             --out-file update-committee.action"
     fi

--- a/start.sh
+++ b/start.sh
@@ -383,26 +383,24 @@ add_new_CC() {
     read -p "Plese provide us with the expiration epoch of a new CC memeber: " expiration_memeber
 
     # Asking the user for quorum
-    read -p "How many members of the committee needs to accept the proposal?" quorum
+    read -p "How many committee members will there be in total?" quorum_denominator
+    read -p "How many members of the committee needs to accept the proposal?" quorum_numerator
+    
+    CC_governance_action_tx_id=$(cardano-cli conway query gov-state --testnet-magic 4 | jq -r .enactState.prevGovActionIds.pgaCommittee.txId)
+    CC_governance_action_index=$(cardano-cli conway query gov-state --testnet-magic 4 | jq -r .enactState.prevGovActionIds.pgaCommittee.govActionIx)
 
-    get_last_enacted_gov_action_ID
-
-    read -p "Is there a previous Governance Action? (yes/no): " user_choice
-
-    if [ "$user_choice" == "yes" ]; then
-        read -p "Please provide Governance Action Tx Id: " governance_action_tx_id
-        read -p "Please provide Governance Action Tx Index: " governance_action_index
+    if [ "$CC_governance_action_tx_id" != "null" ]; then
         command="cardano-cli conway governance action update-committee \
             --testnet \
             --governance-action-deposit ${govActDeposit} \
             --stake-verification-key-file stake.vkey \
             --proposal-anchor-url ${link} \
             --proposal-anchor-metadata-file ${governance_text} \
-            --add-cc-cold-verification-key-has ${CC_memeber} \
-            --epoch ${expiration_memeber} \
-            --quorum ${quorum} \
-            --governance-action-tx-id ${governance_action_tx_id} \
-            --governance-action-index ${governacne_action_index} \
+            --add-cc-cold-verification-key-has ${CC_member} \
+            --epoch ${expiration_member} \
+            --quorum ${quorum_numerator}/${quorum_denominator} \
+            --governance-action-tx-id ${CC_governance_action_tx_id} \
+            --governance-action-index ${CC_governacne_action_index} \
             --out-file update-committee.action"
     else
         command="cardano-cli conway governance action update-committee \
@@ -411,8 +409,8 @@ add_new_CC() {
             --stake-verification-key-file stake.vkey \
             --proposal-anchor-url ${link} \
             --proposal-anchor-metadata-file ${governance_text} \
-            --remove-cc-cold-verification-key-hash ${CC_memeber} \
-            --quorum ${quorum} \
+            --remove-cc-cold-verification-key-hash ${CC_member} \
+            --quorum ${quorum_numerator}/${quorum_denominator} \
             --out-file update-committee.action"
     fi
 


### PR DESCRIPTION
- Modified `governance action update-committee` to allow self-verification of the old CC-governance ID and automatically add it if necessary.
- Add a query of the total number of members submitted (`CC_governance_denominator`) in order to better calculate the quorum and also in order to use the variable in order to have the number of keys-hash submited to the command (in another fonction "TODO")
- I also started to make some changes to the constitution script. I have to know which way you would like to procede with this because there is 3 ways of doing this. I'm also not sure about your proposal text and URL variables (I would love to to talk to you about it.)